### PR TITLE
Fix DirMangaImporter

### DIFF
--- a/app/src/main/java/org/koitharu/kotatsu/local/domain/importer/DirMangaImporter.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/local/domain/importer/DirMangaImporter.kt
@@ -58,7 +58,7 @@ class DirMangaImporter(
 
 	private suspend fun addPages(output: CbzMangaOutput, root: DocumentFile, path: String, state: State) {
 		var number = 0
-		for (file in root.listFiles()) {
+		for (file in root.listFiles().sortedBy {it.name}) {
 			when {
 				file.isDirectory -> {
 					addPages(output, file, path + "/" + file.name, state)


### PR DESCRIPTION
Fixes an issue where the manga pages are imported out-of-order when importing as a directory of pages