### PR TITLE
Add uses of NotificationManagerCompat and related classes

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/download/ui/worker/DownloadNotificationFactory.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/download/ui/worker/DownloadNotificationFactory.kt
@@ -1,13 +1,11 @@
 package org.koitharu.kotatsu.download.ui.worker
 
 import android.app.Notification
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.graphics.drawable.Drawable
-import android.os.Build
 import android.text.format.DateUtils
+import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.PendingIntentCompat
@@ -24,6 +22,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.core.util.ext.getDrawableOrThrow
+import org.koitharu.kotatsu.core.util.ext.printStackTraceDebug
 import org.koitharu.kotatsu.details.ui.DetailsActivity
 import org.koitharu.kotatsu.download.domain.DownloadState
 import org.koitharu.kotatsu.download.ui.list.DownloadsActivity
@@ -32,7 +31,6 @@ import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.util.format
 import org.koitharu.kotatsu.parsers.util.runCatchingCancellable
 import org.koitharu.kotatsu.search.ui.MangaListActivity
-import org.koitharu.kotatsu.core.util.ext.printStackTraceDebug
 import java.util.UUID
 import com.google.android.material.R as materialR
 
@@ -246,20 +244,14 @@ class DownloadNotificationFactory @AssistedInject constructor(
 	}
 
 	private fun createChannel() {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			val manager = NotificationManagerCompat.from(context)
-			if (manager.getNotificationChannel(CHANNEL_ID) == null) {
-				val channel = NotificationChannel(
-					CHANNEL_ID,
-					context.getString(R.string.downloads),
-					NotificationManager.IMPORTANCE_LOW,
-				)
-				channel.enableVibration(false)
-				channel.enableLights(false)
-				channel.setSound(null, null)
-				manager.createNotificationChannel(channel)
-			}
-		}
+		val manager = NotificationManagerCompat.from(context)
+		val channel = NotificationChannelCompat.Builder(CHANNEL_ID, NotificationManagerCompat.IMPORTANCE_LOW)
+			.setName(context.getString(R.string.downloads))
+			.setVibrationEnabled(false)
+			.setLightsEnabled(false)
+			.setSound(null, null)
+			.build()
+		manager.createNotificationChannel(channel)
 	}
 
 	@AssistedFactory

--- a/app/src/main/kotlin/org/koitharu/kotatsu/local/ui/ImportWorker.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/local/ui/ImportWorker.kt
@@ -1,13 +1,12 @@
 package org.koitharu.kotatsu.local.ui
 
 import android.app.Notification
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.net.Uri
-import android.os.Build
+import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.PendingIntentCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
@@ -39,9 +38,7 @@ class ImportWorker @AssistedInject constructor(
 	private val coil: ImageLoader
 ) : CoroutineWorker(appContext, params) {
 
-	private val notificationManager by lazy {
-		applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-	}
+	private val notificationManager by lazy { NotificationManagerCompat.from(appContext) }
 
 	override suspend fun doWork(): Result {
 		val uri = inputData.getString(DATA_URI)?.toUriOrNull() ?: return Result.failure()
@@ -56,14 +53,14 @@ class ImportWorker @AssistedInject constructor(
 
 	override suspend fun getForegroundInfo(): ForegroundInfo {
 		val title = applicationContext.getString(R.string.importing_manga)
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			val channel = NotificationChannel(CHANNEL_ID, title, NotificationManager.IMPORTANCE_LOW)
-			channel.setShowBadge(false)
-			channel.enableVibration(false)
-			channel.setSound(null, null)
-			channel.enableLights(false)
-			notificationManager.createNotificationChannel(channel)
-		}
+		val channel = NotificationChannelCompat.Builder(CHANNEL_ID, NotificationManagerCompat.IMPORTANCE_LOW)
+			.setName(title)
+			.setShowBadge(false)
+			.setVibrationEnabled(false)
+			.setSound(null, null)
+			.setLightsEnabled(false)
+			.build()
+		notificationManager.createNotificationChannel(channel)
 
 		val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
 			.setContentTitle(title)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/local/ui/LocalChaptersRemoveService.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/local/ui/LocalChaptersRemoveService.kt
@@ -1,11 +1,11 @@
 package org.koitharu.kotatsu.local.ui
 
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
-import android.os.Build
+import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import dagger.hilt.android.AndroidEntryPoint
@@ -67,15 +67,15 @@ class LocalChaptersRemoveService : CoroutineIntentService() {
 
 	private fun startForeground() {
 		val title = getString(R.string.local_manga_processing)
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-			val channel = NotificationChannel(CHANNEL_ID, title, NotificationManager.IMPORTANCE_LOW)
-			channel.setShowBadge(false)
-			channel.enableVibration(false)
-			channel.setSound(null, null)
-			channel.enableLights(false)
-			manager.createNotificationChannel(channel)
-		}
+		val manager = NotificationManagerCompat.from(this)
+		val channel = NotificationChannelCompat.Builder(CHANNEL_ID, NotificationManagerCompat.IMPORTANCE_LOW)
+			.setName(title)
+			.setShowBadge(false)
+			.setVibrationEnabled(false)
+			.setSound(null, null)
+			.setLightsEnabled(false)
+			.build()
+		manager.createNotificationChannel(channel)
 
 		val notification = NotificationCompat.Builder(this, CHANNEL_ID)
 			.setContentTitle(title)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/work/TrackWorker.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/work/TrackWorker.kt
@@ -1,13 +1,13 @@
 package org.koitharu.kotatsu.tracker.work
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.os.Build
+import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.VISIBILITY_PUBLIC
 import androidx.core.app.NotificationCompat.VISIBILITY_SECRET
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.PendingIntentCompat
 import androidx.core.content.ContextCompat
 import androidx.hilt.work.HiltWorker
@@ -64,10 +64,7 @@ class TrackWorker @AssistedInject constructor(
 	private val tracker: Tracker,
 	@TrackerLogger private val logger: FileLogger,
 ) : CoroutineWorker(context, workerParams) {
-
-	private val notificationManager by lazy {
-		applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-	}
+	private val notificationManager by lazy { NotificationManagerCompat.from(applicationContext) }
 
 	override suspend fun doWork(): Result {
 		trySetForeground()
@@ -204,18 +201,15 @@ class TrackWorker @AssistedInject constructor(
 
 	override suspend fun getForegroundInfo(): ForegroundInfo {
 		val title = applicationContext.getString(R.string.check_for_new_chapters)
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			val channel = NotificationChannel(
-				WORKER_CHANNEL_ID,
-				title,
-				NotificationManager.IMPORTANCE_LOW,
-			)
-			channel.setShowBadge(false)
-			channel.enableVibration(false)
-			channel.setSound(null, null)
-			channel.enableLights(false)
-			notificationManager.createNotificationChannel(channel)
-		}
+		val channel = NotificationChannelCompat.Builder(WORKER_CHANNEL_ID, NotificationManagerCompat.IMPORTANCE_LOW)
+			.setName(title)
+			.setShowBadge(false)
+			.setVibrationEnabled(false)
+			.setSound(null, null)
+			.setLightsEnabled(false)
+			.build()
+		notificationManager.createNotificationChannel(channel)
+
 		val notification = NotificationCompat.Builder(applicationContext, WORKER_CHANNEL_ID)
 			.setContentTitle(title)
 			.setPriority(NotificationCompat.PRIORITY_MIN)


### PR DESCRIPTION
Add uses of the `NotificationManagerCompat` helper class, as well as related classes such as [`NotificationChannelCompat`](https://developer.android.com/reference/androidx/core/app/NotificationChannelCompat) and [`NotificationChannelGroupCompat`](https://developer.android.com/reference/androidx/core/app/NotificationChannelGroupCompat).