### PR TITLE
Use ConnectivityManagerCompat.getRestrictBackgroundStatus()

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
@@ -2,15 +2,14 @@ package org.koitharu.kotatsu.core.prefs
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.net.ConnectivityManager
 import android.net.Uri
-import android.os.Build
 import android.provider.Settings
 import androidx.annotation.FloatRange
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.collection.ArraySet
 import androidx.collection.arraySetOf
 import androidx.core.content.edit
+import androidx.core.net.ConnectivityManagerCompat
 import androidx.core.os.LocaleListCompat
 import androidx.preference.PreferenceManager
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -334,11 +333,8 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 	}
 
 	private fun isBackgroundNetworkRestricted(): Boolean {
-		return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-			connectivityManager.restrictBackgroundStatus == ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED
-		} else {
-			false
-		}
+		return ConnectivityManagerCompat.getRestrictBackgroundStatus(connectivityManager) ==
+			ConnectivityManagerCompat.RESTRICT_BACKGROUND_STATUS_ENABLED
 	}
 
 	private fun JSONArray.toStringSet(): Set<String> {


### PR DESCRIPTION
Use the [`ConnectivityManagerCompat.getRestrictBackgroundStatus()`](https://developer.android.com/reference/androidx/core/net/ConnectivityManagerCompat#getRestrictBackgroundStatus(android.net.ConnectivityManager)) API. This changes the behavior for Android versions below 7.0 as the method returns `RESTRICT_BACKGROUND_STATUS_ENABLED` for those versions.