### PR TITLE
Use format `yyyyMMdd` for backups

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/backup/BackupZipOutput.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/backup/BackupZipOutput.kt
@@ -39,7 +39,7 @@ suspend fun BackupZipOutput(context: Context): BackupZipOutput = runInterruptibl
 	val filename = buildString {
 		append(context.getString(R.string.app_name).replace(' ', '_').lowercase(Locale.ROOT))
 		append('_')
-		append(LocalDate.now().format(DateTimeFormatter.ofPattern("ddMMyyyy")))
+		append(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd")))
 		append(".bk.zip")
 	}
 	BackupZipOutput(File(dir, filename))


### PR DESCRIPTION
Resolves #791 .