### PR TITLE
0ms DNS Large variant

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/DoHManager.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/DoHManager.kt
@@ -85,9 +85,13 @@ class DoHManager(
 			).build()
 
 		DoHProvider.ZERO_MS -> DnsOverHttps.Builder().client(bootstrapClient)
-			.url("https://0ms.dev/dns-query".toHttpUrl())
-			.resolvePublicAddresses(true)
-			.build()
+			.url("https://2ca4h4crra.cloudflare-gateway.com/dns-query".toHttpUrl())
+			.resolvePrivateAddresses(true)
+			.bootstrapDnsHosts(
+				listOfNotNull(
+					tryGetByIp("2a06:98c1:54::384a"),
+				),
+			).build()
 	}
 
 	private fun tryGetByIp(ip: String): InetAddress? = try {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/DoHManager.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/DoHManager.kt
@@ -86,12 +86,8 @@ class DoHManager(
 
 		DoHProvider.ZERO_MS -> DnsOverHttps.Builder().client(bootstrapClient)
 			.url("https://2ca4h4crra.cloudflare-gateway.com/dns-query".toHttpUrl())
-			.resolvePrivateAddresses(true)
-			.bootstrapDnsHosts(
-				listOfNotNull(
-					tryGetByIp("2a06:98c1:54::384a"),
-				),
-			).build()
+			.resolvePublicAddresses(true)
+			.build()
 	}
 
 	private fun tryGetByIp(ip: String): InetAddress? = try {


### PR DESCRIPTION
To prevent users from getting rate limited while still receiving the benefits of OISD Big and other security filters, using the _"Large"_ variant is highly recommended for mission-critical applications or very big networks.
The _"Small"_ variant blocks automated traffic and not suitable for anything mission-critical.

Recommended to always use DNS-over-HTTPS since Plain DNS is not secure.