### PR TITLE
[Kitsu API] migrate from kitsu.io to kitsu.app

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/scrobbling/kitsu/data/KitsuRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/scrobbling/kitsu/data/KitsuRepository.kt
@@ -28,7 +28,7 @@ import org.koitharu.kotatsu.scrobbling.common.domain.model.ScrobblerService
 import org.koitharu.kotatsu.scrobbling.common.domain.model.ScrobblerUser
 import org.koitharu.kotatsu.scrobbling.kitsu.data.KitsuInterceptor.Companion.VND_JSON
 
-private const val BASE_WEB_URL = "https://kitsu.io"
+private const val BASE_WEB_URL = "https://kitsu.app"
 
 class KitsuRepository(
 	@ApplicationContext context: Context,


### PR DESCRIPTION
The [kitsu.io](https://kitsu.io) domain has expired, and the main developers do not have access to that domain. So they migrated [(official announcement)](https://kitsu.app/posts/9837041) to the new [kitsu.app](https://kitsu.app) domain.

This pull request updates all references of `kitsu.io` to `kitsu.app`.