### PR TITLE
Allow HTTPS connexions to sync servers

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/SyncSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/SyncSettingsFragment.kt
@@ -29,7 +29,7 @@ class SyncSettingsFragment : BasePreferenceFragment(R.string.sync_settings), Fra
 
 	override fun onPreferenceTreeClick(preference: Preference): Boolean {
 		return when (preference.key) {
-			SyncSettings.KEY_HOST -> {
+			SyncSettings.KEY_SYNC_URL -> {
 				SyncHostDialogFragment.show(childFragmentManager, null)
 				true
 			}
@@ -43,7 +43,7 @@ class SyncSettingsFragment : BasePreferenceFragment(R.string.sync_settings), Fra
 	}
 
 	private fun bindHostSummary() {
-		val preference = findPreference<Preference>(SyncSettings.KEY_HOST) ?: return
-		preference.summary = syncSettings.host
+		val preference = findPreference<Preference>(SyncSettings.KEY_SYNC_URL) ?: return
+		preference.summary = syncSettings.syncURL
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/utils/validation/DomainValidator.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/utils/validation/DomainValidator.kt
@@ -1,5 +1,6 @@
 package org.koitharu.kotatsu.settings.utils.validation
 
+import android.webkit.URLUtil
 import okhttp3.HttpUrl
 import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.core.util.EditTextValidator
@@ -20,15 +21,20 @@ class DomainValidator : EditTextValidator() {
 
 	companion object {
 
-		fun isValidDomain(value: String): Boolean = runCatching {
-			require(value.isNotEmpty())
-			val parts = value.split(':')
-			require(parts.size <= 2)
-			val urlBuilder = HttpUrl.Builder()
-			urlBuilder.host(parts.first())
-			if (parts.size == 2) {
-				urlBuilder.port(parts[1].toInt())
+		fun isValidDomain(value: String): Boolean {
+			if ( ! URLUtil.isValidUrl(value) ) {
+				return runCatching {
+					require(value.isNotEmpty())
+					val parts = value.split(':')
+					require(parts.size <= 2)
+					val urlBuilder = HttpUrl.Builder()
+					urlBuilder.host(parts.first())
+					if (parts.size == 2) {
+						urlBuilder.port(parts[1].toInt())
+					}
+				}.isSuccess
 			}
-		}.isSuccess
+			return true
+		}
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/SyncAuthApi.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/SyncAuthApi.kt
@@ -17,13 +17,12 @@ class SyncAuthApi @Inject constructor(
 	@BaseHttpClient private val okHttpClient: OkHttpClient,
 ) {
 
-	suspend fun authenticate(host: String, email: String, password: String): String {
+	suspend fun authenticate(syncURL: String, email: String, password: String): String {
 		val body = JSONObject(
 			mapOf("email" to email, "password" to password),
 		).toRequestBody()
-		val scheme = getScheme(host)
 		val request = Request.Builder()
-			.url("$scheme://$host/auth")
+			.url("$syncURL/auth")
 			.post(body)
 			.build()
 		val response = okHttpClient.newCall(request).await()
@@ -34,14 +33,5 @@ class SyncAuthApi @Inject constructor(
 			val message = response.use { checkNotNull(it.body).string() }.removeSurrounding('"')
 			throw SyncApiException(message, code)
 		}
-	}
-
-	private suspend fun getScheme(host: String): String {
-		val request = Request.Builder()
-			.url("http://$host/")
-			.head()
-			.build()
-		val response = okHttpClient.newCall(request).await()
-		return response.request.url.scheme
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/SyncAuthenticator.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/SyncAuthenticator.kt
@@ -32,7 +32,7 @@ class SyncAuthenticator(
 	private fun tryRefreshToken() = runCatching {
 		runBlocking {
 			authApi.authenticate(
-				syncSettings.host,
+				syncSettings.syncURL,
 				account.name,
 				accountManager.getPassword(account),
 			)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/SyncSettings.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/SyncSettings.kt
@@ -24,22 +24,22 @@ class SyncSettings(
 	)
 
 	private val accountManager = AccountManager.get(context)
-	private val defaultHost = context.getString(R.string.sync_host_default)
+	private val defaultSyncUrl = context.getString(R.string.sync_url_default)
 
 	@get:WorkerThread
 	@set:WorkerThread
-	var host: String
+	var syncURL: String
 		get() = account?.let {
-			accountManager.getUserData(it, KEY_HOST)
-		}.ifNullOrEmpty { defaultHost }
+			accountManager.getUserData(it, KEY_SYNC_URL)
+		}.ifNullOrEmpty { defaultSyncUrl }
 		set(value) {
 			account?.let {
-				accountManager.setUserData(it, KEY_HOST, value)
+				accountManager.setUserData(it, KEY_SYNC_URL, value)
 			}
 		}
 
 	companion object {
 
-		const val KEY_HOST = "host"
+		const val KEY_SYNC_URL = "host"
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/SyncSettings.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/SyncSettings.kt
@@ -30,7 +30,11 @@ class SyncSettings(
 	@set:WorkerThread
 	var syncURL: String
 		get() = account?.let {
-			accountManager.getUserData(it, KEY_SYNC_URL)
+			val sync_url = accountManager.getUserData(it, KEY_SYNC_URL)
+			if ( !sync_url.startsWith("http://") && !sync_url.startsWith("https://") ) {
+				return "http://$sync_url"
+			}
+			return sync_url
 		}.ifNullOrEmpty { defaultSyncUrl }
 		set(value) {
 			account?.let {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/SyncAuthResult.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/SyncAuthResult.kt
@@ -1,7 +1,7 @@
 package org.koitharu.kotatsu.sync.domain
 
 data class SyncAuthResult(
-	val host: String,
+	val syncURL: String,
 	val email: String,
 	val password: String,
 	val token: String,

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/SyncHelper.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/SyncHelper.kt
@@ -60,9 +60,7 @@ class SyncHelper @AssistedInject constructor(
 		.addInterceptor(SyncInterceptor(context, account))
 		.build()
 	private val baseUrl: String by lazy {
-		val host = settings.host
-		val scheme = getScheme(host)
-		"$scheme://$host"
+		settings.syncURL
 	}
 	private val defaultGcPeriod: Long // gc period if sync enabled
 		get() = TimeUnit.DAYS.toMillis(4)
@@ -271,15 +269,6 @@ class SyncHelper @AssistedInject constructor(
 			}
 		}
 		return requireNotNull(tag)
-	}
-
-	private fun getScheme(host: String): String {
-		val request = Request.Builder()
-			.url("http://$host/")
-			.head()
-			.build()
-		val response = httpClient.newCall(request).execute()
-		return response.request.url.scheme
 	}
 
 	private fun gcFavourites() {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthActivity.kt
@@ -104,14 +104,14 @@ class SyncAuthActivity : BaseActivity<ActivitySyncAuthBinding>(), View.OnClickLi
 			}
 
 			R.id.button_settings -> {
-				SyncHostDialogFragment.show(supportFragmentManager, viewModel.host.value)
+				SyncHostDialogFragment.show(supportFragmentManager, viewModel.syncURL.value)
 			}
 		}
 	}
 
 	override fun onFragmentResult(requestKey: String, result: Bundle) {
-		val host = result.getString(SyncHostDialogFragment.KEY_HOST) ?: return
-		viewModel.host.value = host
+		val syncURL = result.getString(SyncHostDialogFragment.KEY_SYNC_URL) ?: return
+		viewModel.syncURL.value = syncURL
 	}
 
 	override fun finish() {
@@ -144,7 +144,7 @@ class SyncAuthActivity : BaseActivity<ActivitySyncAuthBinding>(), View.OnClickLi
 		val am = AccountManager.get(this)
 		val account = Account(authResult.email, getString(R.string.account_type_sync))
 		val userdata = Bundle(1)
-		userdata.putString(SyncSettings.KEY_HOST, authResult.host)
+		userdata.putString(SyncSettings.KEY_SYNC_URL, authResult.syncURL)
 		val result = Bundle()
 		if (am.addAccountExplicitly(account, authResult.password, userdata)) {
 			result.putString(AccountManager.KEY_ACCOUNT_NAME, account.name)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthViewModel.kt
@@ -22,7 +22,7 @@ class SyncAuthViewModel @Inject constructor(
 
 	val onAccountAlreadyExists = MutableEventFlow<Unit>()
 	val onTokenObtained = MutableEventFlow<SyncAuthResult>()
-	val host = MutableStateFlow(context.getString(R.string.sync_host_default))
+	val syncURL = MutableStateFlow(context.getString(R.string.sync_url_default))
 
 	init {
 		launchJob(Dispatchers.Default) {
@@ -35,10 +35,10 @@ class SyncAuthViewModel @Inject constructor(
 	}
 
 	fun obtainToken(email: String, password: String) {
-		val hostValue = host.value
+		val urlValue = syncURL.value
 		launchLoadingJob(Dispatchers.Default) {
-			val token = api.authenticate(hostValue, email, password)
-			val result = SyncAuthResult(host.value, email, password, token)
+			val token = api.authenticate(urlValue, email, password)
+			val result = SyncAuthResult(syncURL.value, email, password, token)
 			onTokenObtained.call(result)
 		}
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncHostDialogFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncHostDialogFragment.kt
@@ -49,7 +49,7 @@ class SyncHostDialogFragment : AlertDialogFragment<PreferenceDialogAutocompletet
 			topMargin = binding.root.resources.getDimensionPixelOffset(R.dimen.screen_padding)
 			bottomMargin = topMargin
 		}
-		binding.message.setText(R.string.sync_url_description)
+		binding.message.setText(R.string.sync_host_description)
 		val entries = binding.root.resources.getStringArray(R.array.sync_url_list)
 		val editText = binding.edit
 		editText.setText(arguments?.getString(KEY_SYNC_URL).ifNullOrEmpty { syncSettings.syncURL })
@@ -66,7 +66,7 @@ class SyncHostDialogFragment : AlertDialogFragment<PreferenceDialogAutocompletet
 			DialogInterface.BUTTON_POSITIVE -> {
 				val result = requireViewBinding().edit.text?.toString().orEmpty()
 				var scheme = ""
-				if ( ! result.startsWith("https://") && ! result.startsWith("http://")) {
+				if (!result.startsWith("https://") && !result.startsWith("http://")) {
 					scheme = "http://"
 				}
 				syncSettings.syncURL = "$scheme$result"

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncHostDialogFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncHostDialogFragment.kt
@@ -49,10 +49,10 @@ class SyncHostDialogFragment : AlertDialogFragment<PreferenceDialogAutocompletet
 			topMargin = binding.root.resources.getDimensionPixelOffset(R.dimen.screen_padding)
 			bottomMargin = topMargin
 		}
-		binding.message.setText(R.string.sync_host_description)
-		val entries = binding.root.resources.getStringArray(R.array.sync_host_list)
+		binding.message.setText(R.string.sync_url_description)
+		val entries = binding.root.resources.getStringArray(R.array.sync_url_list)
 		val editText = binding.edit
-		editText.setText(arguments?.getString(KEY_HOST).ifNullOrEmpty { syncSettings.host })
+		editText.setText(arguments?.getString(KEY_SYNC_URL).ifNullOrEmpty { syncSettings.syncURL })
 		editText.threshold = 0
 		editText.setAdapter(ArrayAdapter(binding.root.context, android.R.layout.simple_spinner_dropdown_item, entries))
 		binding.dropdown.setOnClickListener {
@@ -65,8 +65,12 @@ class SyncHostDialogFragment : AlertDialogFragment<PreferenceDialogAutocompletet
 		when (which) {
 			DialogInterface.BUTTON_POSITIVE -> {
 				val result = requireViewBinding().edit.text?.toString().orEmpty()
-				syncSettings.host = result
-				parentFragmentManager.setFragmentResult(REQUEST_KEY, bundleOf(KEY_HOST to result))
+				var scheme = ""
+				if ( ! result.startsWith("https://") && ! result.startsWith("http://")) {
+					scheme = "http://"
+				}
+				syncSettings.syncURL = "$scheme$result"
+				parentFragmentManager.setFragmentResult(REQUEST_KEY, bundleOf(KEY_SYNC_URL to "$scheme$result"))
 			}
 		}
 		dialog.dismiss()
@@ -75,11 +79,11 @@ class SyncHostDialogFragment : AlertDialogFragment<PreferenceDialogAutocompletet
 	companion object {
 
 		private const val TAG = "SyncHostDialogFragment"
-		const val REQUEST_KEY = "sync_host"
-		const val KEY_HOST = "host"
+		const val REQUEST_KEY = "host"
+		const val KEY_SYNC_URL = "host"
 
-		fun show(fm: FragmentManager, host: String?) = SyncHostDialogFragment().withArgs(1) {
-			putString(KEY_HOST, host)
+		fun show(fm: FragmentManager, syncURL: String?) = SyncHostDialogFragment().withArgs(1) {
+			putString(KEY_SYNC_URL, syncURL)
 		}.show(fm, TAG)
 	}
 }

--- a/app/src/main/res/values/constants.xml
+++ b/app/src/main/res/values/constants.xml
@@ -6,7 +6,7 @@
 	<string name="url_weblate" translatable="false">https://hosted.weblate.org/engage/kotatsu</string>
 	<string name="url_error_report" translatable="false">https://bugs.kotatsu.app/report</string>
 	<string name="account_type_sync" translatable="false">org.kotatsu.sync</string>
-	<string name="sync_host_default" translatable="false">sync.kotatsu.app</string>
+	<string name="sync_url_default" translatable="false">https://sync.kotatsu.app</string>
 	<string name="shikimori_clientId" translatable="false">Mw6F0tPEOgyV7F9U9Twg50Q8SndMY7hzIOfXg0AX_XU</string>
 	<string name="shikimori_clientSecret" translatable="false">euBMt1GGRSDpVIFQVPxZrO7Kh6X4gWyv0dABuj4B-M8</string>
 	<string name="anilist_clientId" translatable="false">9887</string>
@@ -40,8 +40,8 @@
 		<item>0</item>
 		<item>1</item>
 	</string-array>
-	<string-array name="sync_host_list" translatable="false">
-		<item>@string/sync_host_default</item>
+	<string-array name="sync_url_list" translatable="false">
+		<item>@string/sync_url_default</item>
 		<item>moe.shirizu.org</item>
 		<item>86.57.183.214:8081</item>
 	</string-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -375,7 +375,7 @@
 	<string name="find_similar">Find similar</string>
 	<string name="sync_settings">Synchronization settings</string>
 	<string name="server_address">Server address</string>
-	<string name="sync_url_description">You can use a self-hosted synchronization server or a default one. Don\'t change this if you\'re not sure what you\'re doing.</string>
+	<string name="sync_host_description">You can use a self-hosted synchronization server or a default one. Don\'t change this if you\'re not sure what you\'re doing.</string>
 	<string name="ignore_ssl_errors">Ignore SSL errors</string>
 	<string name="mirror_switching">Choose mirror automatically</string>
 	<string name="mirror_switching_summary">Automatically switch domains for manga sources on errors if mirrors are available</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -278,7 +278,7 @@
 	<string name="exclude_nsfw_from_history_summary">Manga marked as NSFW will never be added to the history and your progress will not be saved</string>
 	<string name="clear_cookies_summary">Can help in case of some issues. All authorizations will be invalidated</string>
 	<string name="show_all">Show all</string>
-	<string name="invalid_domain_message">Invalid domain</string>
+	<string name="invalid_domain_message">Invalid server address</string>
 	<string name="select_range">Select range</string>
 	<string name="clear_all_history">Clear all history</string>
 	<string name="last_2_hours">Last 2 hours</string>
@@ -375,7 +375,7 @@
 	<string name="find_similar">Find similar</string>
 	<string name="sync_settings">Synchronization settings</string>
 	<string name="server_address">Server address</string>
-	<string name="sync_host_description">You can use a self-hosted synchronization server or a default one. Don\'t change this if you\'re not sure what you\'re doing.</string>
+	<string name="sync_url_description">You can use a self-hosted synchronization server or a default one. Don\'t change this if you\'re not sure what you\'re doing.</string>
 	<string name="ignore_ssl_errors">Ignore SSL errors</string>
 	<string name="mirror_switching">Choose mirror automatically</string>
 	<string name="mirror_switching_summary">Automatically switch domains for manga sources on errors if mirrors are available</string>


### PR DESCRIPTION
This is a start on making the sync servers be able to use TLS.
I opened an [issue](https://github.com/KotatsuApp/kotatsu-syncserver/issues/12) about it on the sync server repo some time ago, and this is the start of what I have implemented so far.

The TLDR for the above mentioned issue, authentication is happening, and http mean it's send in the clear, wich is obviously not good.

I am not used to program in Kotlin so I wouldn't mind somebody having a look at it before I go further.

The changes are the following:
* A sync server can be specified using a full URL, including the scheme.
This means that you can specify https:// to get a secure connexion to the server. 
  * To keep some kind of backward compatibility, I chose to make http the default when nothing was specified, this way I hope things would just work for people who have already configured the sync service (but I havent tested it yet).
* The domain name validation logic got replaced with a URL validation
  * ~~it seems that the "ok" button is not disabled in the UI when the url is not valid, for some reason I have not dug into yet.~~
  * I saw that the domain validation function is also used in another part of the code, I assume that having the fallback to a domain validation will make it behave as is did before there as well but I haven't tested it, neither have I looked into why it was used somewhere else
* Omitting the scheme also does not pass the URL validation check
  * but since the check is not blocking you can still choose enter only a domain name 🙃
  * This is obviously a not a behaviour I want kept in there, maybe if the URL validation fail, the old domain validation should still be there to check if everything is good  
* A few things have been renamed to make more sense with the changes

I would also be fine with just changing the scheme to always be https, and not allow http connexions, but I though that doing such a change would be very disruptive as servers and clients would need to change together to not be to disruptive (Servers could be just put behind a revers proxy that accepts both https and http to make this more transparent for users ¯\\\_(ツ)\_/¯ )
