### PR TITLE
Give "Complete" status only to fully completed Manga

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/list/domain/ReadingProgress.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/list/domain/ReadingProgress.kt
@@ -38,7 +38,7 @@ data class ReadingProgress(
 	companion object {
 
 		const val PROGRESS_NONE = -1f
-		const val PROGRESS_COMPLETED = 0.995f
+		const val PROGRESS_COMPLETED = 1f
 
 		fun isValid(percent: Float) = percent in 0f..1f
 


### PR DESCRIPTION
Up until now a progress of >= 99.5% would count a Manga as completed (and show the checkmark icon). This causes manga with 200 chapters or more to be marked as completed even if they have at least one unread chapter.

https://github.com/KotatsuApp/Kotatsu/issues/1105

Note: 199/200 = 0.995 --> 1 unread chapter but >= 99.5% progress