### PR TITLE
Issue#1102, proposed name when saving a page changed 

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/PageSaveHelper.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/PageSaveHelper.kt
@@ -116,7 +116,7 @@ class PageSaveHelper @AssistedInject constructor(
 		var currentTime = getCurrentTime()
 		var extension = getPageExtension(pageUrl, pageUri)
 
-		return mangaInfos + "_" + currentTime + "_" + extension
+		return mangaInfos + "_" + currentTime + extension
 	}
 
 	private fun getNameFromMangaChapterPage(manga: Manga, chapter: MangaChapter, pageNumber: Number): String {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderViewModel.kt
@@ -258,9 +258,10 @@ class ReaderViewModel @Inject constructor(
 		val prevJob = pageSaveJob
 		pageSaveJob = launchLoadingJob(Dispatchers.Default) {
 			prevJob?.cancelAndJoin()
-			val currentManga = checkNotNull(getCurrentManga()) { "Cannot find current manga" }
-			val currentChapter = checkNotNull(getCurrentChapter()) { "Cannot find current chapter" }
-			val currentPageNumber = checkNotNull(getPageNumber()) { "Cannot find current page number" }
+			val state = checkNotNull(getCurrentState())
+			val currentManga = manga.requireValue()
+			val currentChapter = checkNotNull(currentManga.findChapter(state.chapterId))
+			val currentPageNumber = state.page
 			val currentPage = checkNotNull(getCurrentPage()) { "Cannot find current page" }
 			val dest = pageSaveHelper.save(currentManga, currentChapter, currentPageNumber, setOf(currentPage))
 			onPageSaved.call(dest)


### PR DESCRIPTION
Proposed name when saving a manga page now is formatted as follows:
<manga_title>-<manga_chapter>-<page_number>_<year>-<month>-<day>_<hour><minute>.<image_extension>