### PR TITLE
fix 100% problem

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/DetailsActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/DetailsActivity.kt
@@ -484,8 +484,10 @@ class DetailsActivity :
 		textViewProgress.textAndVisible = if (info.percent <= 0f) {
 			null
 		} else {
-			getString(R.string.percent_string_pattern, (info.percent * 100f).toInt().toString())
+			val displayPercent = if (info.percent >= 0.999999f) 100 else (info.percent * 100f).toInt()
+			getString(R.string.percent_string_pattern, displayPercent.toString())
 		}
+
 		progress.setProgressCompat(
 			(progress.max * info.percent.coerceIn(0f, 1f)).roundToInt(),
 			true,

--- a/app/src/main/kotlin/org/koitharu/kotatsu/history/data/HistoryRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/history/data/HistoryRepository.kt
@@ -145,10 +145,11 @@ class HistoryRepository @Inject constructor(
 
 	suspend fun getProgress(mangaId: Long, mode: ProgressIndicatorMode): ReadingProgress? {
 		val entity = db.getHistoryDao().find(mangaId) ?: return null
+		val fixedPercent = if (entity.percent >= 0.999999f) 1f else entity.percent
 		return ReadingProgress(
-			percent = entity.percent,
+			percent = fixedPercent,
 			totalChapters = entity.chaptersCount,
-			mode = mode,
+			mode = mode
 		).takeIf { it.isValid() }
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderViewModel.kt
@@ -473,9 +473,15 @@ class ReaderViewModel @Inject constructor(
 		if (chaptersCount == 0 || pagesCount == 0) {
 			return PROGRESS_NONE
 		}
-		val pagePercent = (pageIndex + 1) / pagesCount.toFloat()
+		val pagePercent = (pageIndex + 1).toFloat() / pagesCount
 		val ppc = 1f / chaptersCount
-		return ppc * chapterIndex + ppc * pagePercent
+		var progress = ppc * chapterIndex + ppc * pagePercent
+		
+		if (chapterIndex == chaptersCount - 1 && pageIndex + 1 == pagesCount) {
+			progress = 1.0f
+		}
+
+		return progress
 	}
 
 	private fun observeIsWebtoonZoomEnabled() = settings.observeAsFlow(

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderViewModel.kt
@@ -473,15 +473,9 @@ class ReaderViewModel @Inject constructor(
 		if (chaptersCount == 0 || pagesCount == 0) {
 			return PROGRESS_NONE
 		}
-		val pagePercent = (pageIndex + 1).toFloat() / pagesCount
+		val pagePercent = (pageIndex + 1) / pagesCount.toFloat()
 		val ppc = 1f / chaptersCount
-		var progress = ppc * chapterIndex + ppc * pagePercent
-		
-		if (chapterIndex == chaptersCount - 1 && pageIndex + 1 == pagesCount) {
-			progress = 1.0f
-		}
-
-		return progress
+		return ppc * chapterIndex + ppc * pagePercent
 	}
 
 	private fun observeIsWebtoonZoomEnabled() = settings.observeAsFlow(


### PR DESCRIPTION
if the manga has been read in full, a "check mark" will be displayed on the cover instead of 99%

if the manga has been read in full, the detailed menu in the progress bar will show 100% instead of 99%