### PR TITLE
Implement splash screen for older Android versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,6 +127,7 @@ dependencies {
 
 	implementation libs.androidx.appcompat
 	implementation libs.androidx.core
+	implementation libs.androidx.core.splashscreen
 	implementation libs.androidx.activity
 	implementation libs.androidx.fragment
 	implementation libs.androidx.transition

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,7 +57,7 @@
 		android:requestLegacyExternalStorage="true"
 		android:roundIcon="@mipmap/ic_launcher_round"
 		android:supportsRtl="true"
-		android:theme="@style/Theme.Kotatsu"
+		android:theme="@style/SplashTheme"
 		tools:ignore="UnusedAttribute">
 
 		<activity

--- a/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/MainActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.appcompat.view.ActionMode
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.OnApplyWindowInsetsListener
 import androidx.core.view.SoftwareKeyboardControllerCompat
 import androidx.core.view.ViewCompat
@@ -104,6 +105,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), AppBarOwner, BottomNav
 		get() = viewBinding.bottomNav
 
 	override fun onCreate(savedInstanceState: Bundle?) {
+		installSplashScreen()
 		super.onCreate(savedInstanceState)
 		setContentView(ActivityMainBinding.inflate(layoutInflater))
 		ViewCompat.setOnApplyWindowInsetsListener(viewBinding.root, this)

--- a/app/src/main/res/values-night-v31/themes.xml
+++ b/app/src/main/res/values-night-v31/themes.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-	<style name="Base.V31.Kotatsu" parent="Base.V27.Kotatsu">
-		<item name="android:windowSplashScreenAnimatedIcon">@drawable/avd_splash</item>
-		<item name="android:windowSplashScreenAnimationDuration">@integer/splash_screen_duration</item>
-		<item name="android:windowSplashScreenBackground">@color/m3_sys_color_dynamic_dark_surface</item>
+	<style name="SplashTheme" parent="Theme.SplashScreen">
+		<item name="windowSplashScreenAnimatedIcon">@drawable/avd_splash</item>
+		<item name="windowSplashScreenAnimationDuration">@integer/splash_screen_duration</item>
+		<item name="windowSplashScreenBackground">@color/m3_sys_color_dynamic_dark_surface</item>
+		<item name="postSplashScreenTheme">@style/Theme.Kotatsu</item>
 	</style>
 
 	<!-- From ThemeOverlay.Material3.DynamicColors.Dark -->

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+	<style name="SplashTheme" parent="Theme.SplashScreen.IconBackground">
+		<item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_foreground</item>
+		<item name="windowSplashScreenAnimationDuration">@integer/splash_screen_duration</item>
+		<item name="windowSplashScreenIconBackgroundColor">@color/kotatsu_primaryContainer</item>
+		<item name="postSplashScreenTheme">@style/Theme.Kotatsu</item>
+	</style>
+
 	<style name="ThemeOverlay.Kotatsu" parent="ThemeOverlay.Material3.Dark">
 		<item name="android:navigationBarColor">@android:color/transparent</item>
 	</style>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-	<style name="Base.V31.Kotatsu" parent="Base.V27.Kotatsu">
-		<item name="android:windowSplashScreenAnimatedIcon">@drawable/avd_splash</item>
-		<item name="android:windowSplashScreenAnimationDuration">@integer/splash_screen_duration</item>
-		<item name="android:windowSplashScreenBackground">@color/m3_sys_color_dynamic_light_surface</item>
+	<style name="SplashTheme" parent="Theme.SplashScreen">
+		<item name="windowSplashScreenAnimatedIcon">@drawable/avd_splash</item>
+		<item name="windowSplashScreenAnimationDuration">@integer/splash_screen_duration</item>
+		<item name="windowSplashScreenBackground">@color/m3_sys_color_dynamic_light_surface</item>
+		<item name="postSplashScreenTheme">@style/Theme.Kotatsu</item>
 	</style>
-
-	<style name="Theme.Kotatsu" parent="Base.V31.Kotatsu" />
 
 	<!-- From ThemeOverlay.Material3.DynamicColors.Light -->
 	<style name="Theme.Kotatsu.Monet">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
+	<style name="SplashTheme" parent="Theme.SplashScreen.IconBackground">
+		<item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_foreground</item>
+		<item name="windowSplashScreenAnimationDuration">@integer/splash_screen_duration</item>
+		<item name="windowSplashScreenIconBackgroundColor">@color/kotatsu_primaryContainer</item>
+		<item name="postSplashScreenTheme">@style/Theme.Kotatsu</item>
+	</style>
+
 	<!-- Base application theme. -->
 	<style name="Base.Theme.Kotatsu" parent="Theme.Material3.DayNight.NoActionBar">
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ parsers = "77a5216ebf"
 preference = "1.2.1"
 recyclerview = "1.4.0"
 room = "2.6.1"
+splashscreen = "1.0.1"
 ssiv = "ba48c29803"
 swiperefreshlayout = "1.1.0"
 testRules = "1.6.1"
@@ -56,6 +57,7 @@ androidx-biometric = { module = "androidx.biometric:biometric-ktx", version.ref 
 androidx-collection = { module = "androidx.collection:collection-ktx", version.ref = "collections" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "splashscreen" }
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hilt" }
 androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "hilt" }


### PR DESCRIPTION
Implement a splash screen similar to the one on Android 12 and later for Android 6.0 and later. More information can be found [here](https://developer.android.com/reference/kotlin/androidx/core/splashscreen/SplashScreen).

**Demo (Android 6.0)**

https://github.com/user-attachments/assets/4d403491-0912-40d8-ab54-f30336286064
