### PR TITLE
UI: Remove contrast in EdgeToEdge navigation bar

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/ui/BaseActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/ui/BaseActivity.kt
@@ -3,11 +3,13 @@ package org.koitharu.kotatsu.core.ui
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
+import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.View
 import android.widget.Toast
+import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.annotation.CallSuper
 import androidx.appcompat.app.AppCompatActivity
@@ -67,7 +69,7 @@ abstract class BaseActivity<B : ViewBinding> :
 		}
 		putDataToExtras(intent)
 		exceptionResolver = entryPoint.exceptionResolverFactory.create(this)
-		enableEdgeToEdge()
+		enableEdgeToEdgeNoContrast()
 		super.onCreate(savedInstanceState)
 	}
 
@@ -97,6 +99,17 @@ abstract class BaseActivity<B : ViewBinding> :
 		ViewCompat.setOnApplyWindowInsetsListener(binding.root, this)
 		val toolbar = (binding.root.findViewById<View>(R.id.toolbar) as? Toolbar)
 		toolbar?.let(this::setSupportActionBar)
+	}
+
+	private fun enableEdgeToEdgeNoContrast() {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+			enableEdgeToEdge(
+				navigationBarStyle = SystemBarStyle.auto(
+					Color.TRANSPARENT, Color.TRANSPARENT
+				)
+			)
+			window.isNavigationBarContrastEnforced = false
+		}
 	}
 
 	protected fun setDisplayHomeAsUp(isEnabled: Boolean, showUpAsClose: Boolean) {


### PR DESCRIPTION
Resolves navigation bar overlay using "enforce contrast" on some vendor operating systems such as Xiaomi

Also remove for button navigation mode like #1341

Before:

![Screenshot_2025-04-09-23-55-29-620_org koitharu kotatsu-edit 1](https://github.com/user-attachments/assets/82b0f1b3-92fa-4bf8-9701-90761c4035c8)

After:

![Screenshot_2025-04-09-23-55-48-128_org koitharu kotatsu nightly-edit 1](https://github.com/user-attachments/assets/c13afb6a-8ac8-4f68-bae3-e22b16da8a1d)