### PR TITLE
Remove "theme_name_dynamic_v2" string

### DIFF
--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -810,7 +810,6 @@
     <string name="error_disclaimer_report">Вы можаце адправіць справаздачу аб памылцы распрацоўшчыкам. Гэта дапаможа нам выправіць праблему.</string>
     <string name="error_disclaimer_app_outdated">Падобна, што Ваша версія Kotatsu састарэлая. Калі ласка, усталюйце апошнюю версію, каб атрымаць усе даступныя выпраўленні.</string>
     <string name="exclude_nsfw_from_suggestions_summary">Дарослая манга не будзе адлюстроўвацца ў рэкамендацыях. Гэтая опцыя можа не працаваць з некаторымі крыніцамі</string>
-    <string name="theme_name_dynamic_v2">Дынамічная V2</string>
     <string name="disable_captcha_notifications_summary">Вы не будзеце атрымліваць апавяшчэнняў аб рашэнні CAPTCHA для гэтай крыніцы, але гэта можа прывесці да парушэння фонавых аперацый (праверкі новых раздзелаў, атрымання рэкамендацый і г.д.)</string>
     <string name="error_disclaimer_manga">Паспрабуйце адкрыць мангу ў браўзэры, каб пераканацца, што яна даступная ў крыніцы.</string>
     <string name="manga_override_hint">Гэтыя змены будуць уплываць на тое, як манга адлюстроўваецца ў праграме</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -816,7 +816,6 @@
     <string name="incognito_for_nsfw">Modalità incognito per manga NSFW</string>
     <string name="dont_ask_again">Non chiedere più</string>
     <string name="incognito_mode_hint_nsfw">Questo manga potrebbe contenere contenuti per adulti. Vuoi utilizzare la modalità incognito?</string>
-    <string name="theme_name_dynamic_v2">Dinamico V2</string>
     <string name="additional_action_required">È necessaria un\'azione aggiuntiva</string>
     <string name="theme_name_expressive">Espressivo (Test)</string>
     <string name="hide_from_main_screen">Nascondi dalla schermata principale</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -803,7 +803,6 @@
     <string name="exclude_nsfw_from_suggestions_summary">Mangás adultos não serão exibidos nas sugestões. Essa opção pode funcionar de forma imprecisa com algumas fontes</string>
     <string name="include_disabled_sources">Incluir fontes desabilitadas</string>
     <string name="suggestions_disabled_sources_summary">Mostrar sugestões de todas as fontes de mangá, incluindo as desabilitadas</string>
-    <string name="theme_name_dynamic_v2">Dinâmico V2</string>
     <string name="manga_override_hint">Essas mudanças afetarão como o mangá é exibido no aplicativo</string>
     <string name="use_default_cover">Usar a capa padrão</string>
     <string name="pick_manga_page">Escolha a página do mangá</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -816,5 +816,4 @@
     <string name="pick_manga_page">Выбрать страницу манги</string>
     <string name="pick_custom_file">Выбрать пользовательский файл</string>
     <string name="page_switch_timer">Страница будет меняться каждые ~%d секунд</string>
-    <string name="theme_name_dynamic_v2">Динамическая V2</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -816,7 +816,6 @@
     <string name="dont_ask_again">Tekrar sorma</string>
     <string name="incognito_mode_hint_nsfw">Bu manga yetişkin içeriği içerebilir. Gizli modu kullanmak ister misiniz?</string>
     <string name="incognito_for_nsfw">NSFW mangaları için gizli mod</string>
-    <string name="theme_name_dynamic_v2">Dinamik V2</string>
     <string name="additional_action_required">Ek işlemler gerekli</string>
     <string name="theme_name_expressive">İfadesel (Test)</string>
     <string name="hide_from_main_screen">Ana ekrandan gizle</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -814,7 +814,6 @@
     <string name="dont_ask_again">Không hỏi lại lần nữa</string>
     <string name="incognito_for_nsfw">Bật chế độ ẩn danh đối với truyện tranh người lớn</string>
     <string name="incognito_mode_hint_nsfw">Truyện này có thể có chứa nội dung dành cho người lớn. Bạn có muốn sử dụng chế độ ẩn danh không?</string>
-    <string name="theme_name_dynamic_v2">Động v2</string>
     <string name="theme_name_expressive">Expressive (Thử nghiệm)</string>
     <string name="additional_action_required">Bắt buộc cần có hành động bổ sung</string>
     <string name="hide_from_main_screen">Ẩn khỏi giao diện màn hình chính</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -815,6 +815,5 @@
     <string name="incognito_for_nsfw">R18无痕模式</string>
     <string name="incognito_mode_hint_nsfw">此漫画可能包含成人内容，需要打开无痕模式继续浏览吗？</string>
     <string name="dont_ask_again">不再询问</string>
-    <string name="theme_name_dynamic_v2">动态 V2</string>
     <string name="hide_from_main_screen">从主页面中隐藏</string>
 </resources>


### PR DESCRIPTION
Fix `"theme_name_dynamic_v2" is translated here but not found in default locale` errors in Nightly build: https://github.com/KotatsuApp/Kotatsu-nightly/actions/runs/15358390725