### PR TITLE
Fix ForegroundServiceStartNotAllowedException on Android 12+

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/download/ui/worker/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/download/ui/worker/DownloadWorker.kt
@@ -526,6 +526,7 @@ class DownloadWorker @AssistedInject constructor(
 					.setConstraints(constraints)
 					.addTag(TAG)
 					.setId(work.id)
+					.setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
 					.build()
 				workManager.awaitUpdateWork(request)
 			}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/local/ui/LocalStorageCleanupWorker.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/local/ui/LocalStorageCleanupWorker.kt
@@ -52,6 +52,7 @@ class LocalStorageCleanupWorker @AssistedInject constructor(
 				.setConstraints(constraints)
 				.addTag(TAG)
 				.setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
+				.setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
 				.build()
 			WorkManager.getInstance(context).enqueueUniqueWork(TAG, ExistingWorkPolicy.KEEP, request).await()
 		}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/suggestions/ui/SuggestionsWorker.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/suggestions/ui/SuggestionsWorker.kt
@@ -415,6 +415,7 @@ class SuggestionsWorker @AssistedInject constructor(
 				.setConstraints(createConstraints())
 				.addTag(TAG)
 				.setBackoffCriteria(BackoffPolicy.LINEAR, 1, TimeUnit.HOURS)
+				.setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
 				.build()
 			workManager
 				.enqueueUniquePeriodicWork(TAG, ExistingPeriodicWorkPolicy.UPDATE, request)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/work/TrackWorker.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/work/TrackWorker.kt
@@ -289,6 +289,7 @@ class TrackWorker @AssistedInject constructor(
 				.setConstraints(constraints)
 				.addTag(TAG)
 				.setBackoffCriteria(BackoffPolicy.LINEAR, 30, TimeUnit.MINUTES)
+				.setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
 				.build()
 			workManager
 				.enqueueUniquePeriodicWork(TAG, ExistingPeriodicWorkPolicy.UPDATE, request)


### PR DESCRIPTION
## Problem
App crashes on Android 12+ with ForegroundServiceStartNotAllowedException when WorkManager tries to start foreground services from background.

## Root Cause  
Several WorkManager requests were missing `.setExpedited()` calls, causing inconsistent behavior.

## Solution
Added `setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)` to:
- DownloadFactory.kt - updateConstraints() 
- LocalStorageCleanupWorker.kt - enqueue()
- SuggestionsWorker scheduler - schedule()
- TrackWorker scheduler - schedule()

## Testing Needed
Needs verification on Android 12+ devices.

Fixes #924 