### PR TITLE
Allow inverting hardware button controls

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
@@ -143,6 +143,9 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 	val isReaderControlAlwaysLTR: Boolean
 		get() = prefs.getBoolean(KEY_READER_CONTROL_LTR, false)
 
+	val isReaderNavigationInverted: Boolean
+		get() = prefs.getBoolean(KEY_READER_NAVIGATION_INVERTED, false)
+
 	val isReaderFullscreenEnabled: Boolean
 		get() = prefs.getBoolean(KEY_READER_FULLSCREEN, true)
 
@@ -631,6 +634,7 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 		const val KEY_READER_DOUBLE_PAGES = "reader_double_pages"
 		const val KEY_READER_ZOOM_BUTTONS = "reader_zoom_buttons"
 		const val KEY_READER_CONTROL_LTR = "reader_taps_ltr"
+		const val KEY_READER_NAVIGATION_INVERTED = "reader_navigation_inverted"
 		const val KEY_READER_FULLSCREEN = "reader_fullscreen"
 		const val KEY_READER_VOLUME_BUTTONS = "reader_volume_buttons"
 		const val KEY_READER_ORIENTATION = "reader_orientation"

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderControlDelegate.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderControlDelegate.kt
@@ -60,28 +60,28 @@ class ReaderControlDelegate(
 			KeyEvent.KEYCODE_L -> switchBy(-1, null, false)
 
 			KeyEvent.KEYCODE_VOLUME_UP -> if (settings.isReaderVolumeButtonsEnabled) {
-				switchBy(-1, event, false)
+				switchBy(if (settings.isReaderNavigationInverted) 1 else -1, event, false)
 			} else {
 				return false
 			}
 
 			KeyEvent.KEYCODE_VOLUME_DOWN -> if (settings.isReaderVolumeButtonsEnabled) {
-				switchBy(1, event, false)
+				switchBy(if (settings.isReaderNavigationInverted) -1 else 1, event, false)
 			} else {
 				return false
 			}
 
-			KeyEvent.KEYCODE_DPAD_RIGHT -> switchByRelative(1, event)
+			KeyEvent.KEYCODE_DPAD_RIGHT -> switchByRelative(if (settings.isReaderNavigationInverted) -1 else 1, event)
 
-			KeyEvent.KEYCODE_DPAD_LEFT -> switchByRelative(-1, event)
+			KeyEvent.KEYCODE_DPAD_LEFT -> switchByRelative(if (settings.isReaderNavigationInverted) 1 else -1, event)
 
 			KeyEvent.KEYCODE_DPAD_CENTER -> listener.toggleUiVisibility()
 
 			KeyEvent.KEYCODE_SYSTEM_NAVIGATION_UP,
-			KeyEvent.KEYCODE_DPAD_UP -> switchBy(-1, event, true)
+			KeyEvent.KEYCODE_DPAD_UP -> switchBy(if (settings.isReaderNavigationInverted) 1 else -1, event, true)
 
 			KeyEvent.KEYCODE_SYSTEM_NAVIGATION_DOWN,
-			KeyEvent.KEYCODE_DPAD_DOWN -> switchBy(1, event, true)
+			KeyEvent.KEYCODE_DPAD_DOWN -> switchBy(if (settings.isReaderNavigationInverted) -1 else 1, event, true)
 
 			else -> return false
 		}
@@ -95,10 +95,10 @@ class ReaderControlDelegate(
 
 	private fun processAction(action: TapAction) {
 		when (action) {
-			TapAction.PAGE_NEXT -> listener.switchPageBy(1)
-			TapAction.PAGE_PREV -> listener.switchPageBy(-1)
-			TapAction.CHAPTER_NEXT -> listener.switchChapterBy(1)
-			TapAction.CHAPTER_PREV -> listener.switchChapterBy(-1)
+			TapAction.PAGE_NEXT -> listener.switchPageBy(if (settings.isReaderNavigationInverted) -1 else 1)
+			TapAction.PAGE_PREV -> listener.switchPageBy(if (settings.isReaderNavigationInverted) 1 else -1)
+			TapAction.CHAPTER_NEXT -> listener.switchChapterBy(if (settings.isReaderNavigationInverted) -1 else 1)
+			TapAction.CHAPTER_PREV -> listener.switchChapterBy(if (settings.isReaderNavigationInverted) 1 else -1)
 			TapAction.TOGGLE_UI -> listener.toggleUiVisibility()
 			TapAction.SHOW_MENU -> listener.openMenu()
 		}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderControlDelegate.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderControlDelegate.kt
@@ -95,10 +95,10 @@ class ReaderControlDelegate(
 
 	private fun processAction(action: TapAction) {
 		when (action) {
-			TapAction.PAGE_NEXT -> listener.switchPageBy(if (settings.isReaderNavigationInverted) -1 else 1)
-			TapAction.PAGE_PREV -> listener.switchPageBy(if (settings.isReaderNavigationInverted) 1 else -1)
-			TapAction.CHAPTER_NEXT -> listener.switchChapterBy(if (settings.isReaderNavigationInverted) -1 else 1)
-			TapAction.CHAPTER_PREV -> listener.switchChapterBy(if (settings.isReaderNavigationInverted) 1 else -1)
+			TapAction.PAGE_NEXT -> listener.switchPageBy(1)
+			TapAction.PAGE_PREV -> listener.switchPageBy(-1)
+			TapAction.CHAPTER_NEXT -> listener.switchChapterBy(1)
+			TapAction.CHAPTER_PREV -> listener.switchChapterBy(-1)
 			TapAction.TOGGLE_UI -> listener.toggleUiVisibility()
 			TapAction.SHOW_MENU -> listener.openMenu()
 		}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -566,7 +566,7 @@
 	<string name="switch_pages_volume_buttons">Enable volume buttons</string>
 	<string name="switch_pages_volume_buttons_summary">Use volume buttons for switching pages</string>
 	<string name="reader_navigation_inverted">Invert navigation controls</string>
-	<string name="reader_navigation_inverted_summary">Swap the direction of volume button and screen tap navigation (left becomes right, right becomes left)</string>
+	<string name="reader_navigation_inverted_summary">Swap the direction of volume button and hardware key navigation (left becomes right, right becomes left)</string>
 	<string name="tap_action">Tap action</string>
 	<string name="long_tap_action">Long tap action</string>
 	<string name="none">None</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -565,6 +565,8 @@
 	<string name="reader_actions_summary">Configure actions for tappable screen areas</string>
 	<string name="switch_pages_volume_buttons">Enable volume buttons</string>
 	<string name="switch_pages_volume_buttons_summary">Use volume buttons for switching pages</string>
+	<string name="reader_navigation_inverted">Invert navigation controls</string>
+	<string name="reader_navigation_inverted_summary">Swap the direction of volume button and screen tap navigation (left becomes right, right becomes left)</string>
 	<string name="tap_action">Tap action</string>
 	<string name="long_tap_action">Long tap action</string>
 	<string name="none">None</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -566,7 +566,7 @@
 	<string name="switch_pages_volume_buttons">Enable volume buttons</string>
 	<string name="switch_pages_volume_buttons_summary">Use volume buttons for switching pages</string>
 	<string name="reader_navigation_inverted">Invert navigation controls</string>
-	<string name="reader_navigation_inverted_summary">Swap the direction of volume button and hardware key navigation (left becomes right, right becomes left)</string>
+	<string name="reader_navigation_inverted_summary">Swap the direction of volume button and directional hardware key navigation (left/up/down/right)</string>
 	<string name="tap_action">Tap action</string>
 	<string name="long_tap_action">Long tap action</string>
 	<string name="none">None</string>

--- a/app/src/main/res/xml/pref_reader.xml
+++ b/app/src/main/res/xml/pref_reader.xml
@@ -75,6 +75,12 @@
 		android:summary="@string/switch_pages_volume_buttons_summary"
 		android:title="@string/switch_pages_volume_buttons" />
 
+	<SwitchPreferenceCompat
+		android:defaultValue="false"
+		android:key="reader_navigation_inverted"
+		android:summary="@string/reader_navigation_inverted_summary"
+		android:title="@string/reader_navigation_inverted" />
+
 	<ListPreference
 		android:entries="@array/reader_animation"
 		android:key="reader_animation2"


### PR DESCRIPTION
👋 I noticed that recently the [control direction for hardware buttons](https://github.com/KotatsuApp/Kotatsu/commit/8ad28fd5092ac828d24ca491eb147439000b81ea) was corrected. 

However I was [using a workflow](https://xkcd.com/1172/) that relied on the buttons being incorrect in the previous version. I'll illustrate it with this image:

<img src="https://github.com/user-attachments/assets/576c3923-9ce1-4107-8f8a-0b78980aa7f8" width="200px" />

This PR introduces a toggle to allow inversion of left/right/up/down for hardware buttons (and volume keys)