### PR TITLE
Fix(reader): Fix incorrect scaling for short images in webtoon reader

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/webtoon/WebtoonImageView.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/webtoon/WebtoonImageView.kt
@@ -40,7 +40,7 @@ class WebtoonImageView @JvmOverloads constructor(
 	fun scrollTo(y: Int) {
 		val maxScroll = getScrollRange()
 		if (maxScroll == 0) {
-			resetScaleAndCenter()
+			scrollToInternal(0)
 			return
 		}
 		scrollToInternal(y.coerceIn(0, maxScroll))


### PR DESCRIPTION
When an image in the webtoon reader is shorter than the screen height, it was being incorrectly scaled, causing it to appear zoomed in or cropped.

This was caused by the `scrollTo` function in `WebtoonImageView.kt` calling `resetScaleAndCenter()` for images with a scroll range of zero. This method, from the underlying SubsamplingScaleImageView library, resets the image to a default scale instead of using the custom logic required by the reader.

The fix replaces the call to `resetScaleAndCenter()` with `scrollToInternal(0)`. This ensures that the custom scaling logic, which fits the image to the screen width, is applied consistently to all images, regardless of their height.