### PR TITLE
Fix/UI bug about finding chapter

### DIFF
--- a/app/src/main/res/menu/opt_chapters.xml
+++ b/app/src/main/res/menu/opt_chapters.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu
+	xmlns:tools="http://schemas.android.com/tools"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res-auto">
 
@@ -9,7 +10,8 @@
 		android:orderInCategory="10"
 		android:title="@string/search_chapters"
 		app:actionViewClass="androidx.appcompat.widget.SearchView"
-		app:showAsAction="ifRoom|collapseActionView" />
+		app:showAsAction="always|collapseActionView"
+		tools:ignore="AlwaysShowAction" />
 
 	<item
 		android:id="@+id/action_downloaded"


### PR DESCRIPTION
Fixes[#1626](https://github.com/KotatsuApp/Kotatsu/issues/1626)

showAsAction="ifRoom|collapseActionView" -> "always|collapseActionView"
because with the typing area, there is never room for the search logo

