### PR TITLE
Increase auto scroll speed limit

### DIFF
--- a/app/src/main/res/layout/view_scroll_timer.xml
+++ b/app/src/main/res/layout/view_scroll_timer.xml
@@ -67,7 +67,7 @@
 		android:contentDescription="@string/speed"
 		android:labelFor="@id/switch_scroll_timer"
 		android:valueFrom="0.000001"
-		android:valueTo="0.95"
+		android:valueTo="0.97"
 		app:labelBehavior="floating"
 		app:layout_constraintEnd_toEndOf="parent"
 		app:layout_constraintStart_toEndOf="@id/label_timer"


### PR DESCRIPTION
Fixes #1544

This pull request makes a small adjustment to the view_scroll_timer.xml layout file by increasing the maximum value (valueTo) of a UI component from 0.95 to 0.97.

The previous limit was too slow for webtoon reading. With this change, the displayed speed values (0.1x to 11.2x) remain the same as before, but each level is now slightly faster. This may affect users who are used to a specific reading speed.