### PR TITLE
feat(settings): Add "Every 6 hours" option for periodic backups

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
@@ -546,11 +546,11 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 	val isPeriodicalBackupEnabled: Boolean
 		get() = prefs.getBoolean(KEY_BACKUP_PERIODICAL_ENABLED, false)
 
-	val periodicalBackupFrequency: Long
-		get() = prefs.getString(KEY_BACKUP_PERIODICAL_FREQUENCY, null)?.toLongOrNull() ?: 7L
+	val periodicalBackupFrequency: Float
+		get() = prefs.getString(KEY_BACKUP_PERIODICAL_FREQUENCY, null)?.toFloatOrNull() ?: 7f
 
 	val periodicalBackupFrequencyMillis: Long
-		get() = TimeUnit.DAYS.toMillis(periodicalBackupFrequency)
+		get() = (TimeUnit.DAYS.toMillis(1) * periodicalBackupFrequency).toLong()
 
 	val periodicalBackupMaxCount: Int
 		get() = if (prefs.getBoolean(KEY_BACKUP_PERIODICAL_TRIM, true)) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -75,6 +75,7 @@
 		<item>@string/advanced</item>
 	</string-array>
 	<string-array name="backup_frequency" translatable="false">
+		<item>@string/frequency_every_6_hours</item>
 		<item>@string/frequency_every_day</item>
 		<item>@string/frequency_every_2_days</item>
 		<item>@string/frequency_once_per_week</item>

--- a/app/src/main/res/values/constants.xml
+++ b/app/src/main/res/values/constants.xml
@@ -56,6 +56,7 @@
 		<item>SOCKS</item>
 	</string-array>
 	<string-array name="values_backup_frequency" translatable="false">
+		<item>0.25</item>
 		<item>1</item>
 		<item>2</item>
 		<item>7</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -498,6 +498,7 @@
     <string name="online_variant">Online variant</string>
     <string name="periodic_backups">Periodic backups</string>
     <string name="backup_frequency">Backup creation frequency</string>
+    <string name="frequency_every_6_hours">Every 6 hours</string>
     <string name="frequency_every_day">Every day</string>
     <string name="frequency_every_2_days">Every 2 days</string>
     <string name="frequency_once_per_week">Once per week</string>


### PR DESCRIPTION
Adds a new "Every 6 hours" frequency option to the periodic backup settings.

To maintain consistency with the existing preference values, which are stored in days, this new option is represented internally as a fractional value of `0.25` days.

The implementation includes:
- Adding the new string resource and updating the preference arrays.
- Changing the preference type in `AppSettings.kt` from `Long` to `Float` to accommodate the fractional value.
- Updating the millisecond conversion logic to correctly calculate the interval from a float value in days.

This approach avoids a complex data migration and is simpler and safer than changing the base unit for all values from days to hours.