### PR TITLE
Add pinned search filtering and hide empty results option

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/search/ui/multi/SearchActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/search/ui/multi/SearchActivity.kt
@@ -94,7 +94,7 @@ class SearchActivity :
 		setDisplayHomeAsUp(isEnabled = true, showUpAsClose = false)
 		supportActionBar?.setSubtitle(R.string.search_results)
 
-		addMenuProvider(SearchKindMenuProvider(this, viewModel.query, viewModel.kind))
+		addMenuProvider(SearchKindMenuProvider(this, viewModel, viewModel.query, viewModel.kind))
 
 		viewModel.list.observe(this, adapter)
 		viewModel.onError.observeEvent(this, SnackbarErrorObserver(viewBinding.recyclerView, null))

--- a/app/src/main/kotlin/org/koitharu/kotatsu/search/ui/multi/SearchKindMenuProvider.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/search/ui/multi/SearchKindMenuProvider.kt
@@ -11,8 +11,9 @@ import org.koitharu.kotatsu.search.domain.SearchKind
 
 class SearchKindMenuProvider(
 	private val activity: SearchActivity,
+	private val viewModel: SearchViewModel,
 	private val query: String,
-	private val kind: SearchKind
+	private val kind: SearchKind,
 ) : MenuProvider {
 
 	override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
@@ -32,6 +33,20 @@ class SearchKindMenuProvider(
 	}
 
 	override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+		when (menuItem.itemId) {
+			R.id.action_filter_pinned_only -> {
+				menuItem.isChecked = !menuItem.isChecked
+				viewModel.setPinnedOnly(menuItem.isChecked)
+				return true
+			}
+
+			R.id.action_filter_hide_empty -> {
+				menuItem.isChecked = !menuItem.isChecked
+				viewModel.setHideEmpty(menuItem.isChecked)
+				return true
+			}
+		}
+
 		val newKind = when (menuItem.itemId) {
 			R.id.action_kind_simple -> SearchKind.SIMPLE
 			R.id.action_kind_title -> SearchKind.TITLE

--- a/app/src/main/res/menu/opt_search_kind.xml
+++ b/app/src/main/res/menu/opt_search_kind.xml
@@ -33,6 +33,20 @@
 					android:title="@string/genre" />
 
 			</group>
+
+			<group android:id="@+id/group_search_filters">
+
+				<item
+					android:id="@+id/action_filter_pinned_only"
+					android:checkable="true"
+					android:title="@string/pinned_sources_only" />
+
+				<item
+					android:id="@+id/action_filter_hide_empty"
+					android:checkable="true"
+					android:title="@string/hide_empty_sources" />
+
+			</group>
 		</menu>
 
 	</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,6 +210,8 @@
     <string name="disabled">Disabled</string>
     <string name="reset_filter">Reset filter</string>
     <string name="enter_name">Enter name</string>
+    <string name="pinned_sources_only">Pinned sources only</string>
+    <string name="hide_empty_sources">Hide empty sources</string>
     <string name="onboard_text">Select languages which you want to read manga. You can change it later in settings.</string>
     <string name="never">Never</string>
     <string name="only_using_wifi">Only on Wi-Fi</string>


### PR DESCRIPTION
## Description
This PR introduces two new filtering options for the search functionality:
### Features:
1. **Pinned Sources Only Filter** - Allows users to filter and display search results only from pinned sources
2. **Hide Empty Results Filter** - Enables users to hide search result groups that don't contain any items
### Changes:
- Added `pinnedOnly` and `hideEmpty` state flows to SearchViewModel
- Implemented menu item handlers in SearchKindMenuProvider for both filter options
- Added methods `setPinnedOnly()` and `setHideEmpty()` to manage filter states
- Updated search logic to respect these filters when fetching results
- Added new menu items to opt_search_kind.xml
- Added string resources for the new filter options
### Testing:
Please verify that:
- Users can toggle the "Pinned sources only" filter and see only results from pinned sources
- Users can toggle the "Hide empty sources" filter and empty source groups are hidden
- Filters work correctly in combination with existing search functionality
### Related Issues:
Closes #1680
Closes #1708